### PR TITLE
Support for brokers that require authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <!-- dependency versions -->
     <camel.version>2.17.2</camel.version>
     <fabric8.version>2.2.144</fabric8.version>
-    <fabric8-ipaas.version>2.2.103</fabric8-ipaas.version>
     <spring-boot.version>1.3.6.RELEASE</spring-boot.version>
 
     <!-- maven plugin versions -->
@@ -60,11 +59,6 @@
 
     <!-- ActiveMQ -->
     <dependency>
-      <groupId>io.fabric8.ipaas.mq</groupId>
-      <artifactId>mq-client</artifactId>
-      <version>${fabric8-ipaas.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-camel</artifactId>
     </dependency>
@@ -83,10 +77,6 @@
       <artifactId>camel-spring-boot-starter</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>

--- a/src/main/resources/META-INF/spring/amq.xml
+++ b/src/main/resources/META-INF/spring/amq.xml
@@ -5,7 +5,14 @@
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <!-- Discovers the ActiveMQ service dynamically -->
-    <bean id="jmsConnectionFactory" class="io.fabric8.mq.core.MQConnectionFactory"/>
+    <bean id="jmsConnectionFactory" class="io.fabric8.mq.core.MQConnectionFactory">
+        <!--
+            If required, you can set the broker credentials using environment variables.
+            Variable names are 'ACTIVEMQ_BROKER_USERNAME' and 'ACTIVEMQ_BROKER_PASSWORD'.
+        -->
+        <property name="userName" value="${activemq.broker.username:#{null}}" />
+        <property name="password" value="${activemq.broker.password:#{null}}" />
+    </bean>
 
     <bean primary="true" id="pooledConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory" init-method="start" destroy-method="stop">
         <property name="maxConnections" value="8"/>
@@ -26,13 +33,6 @@
         <property name="transacted" value="true"/>
         <property name="cacheLevelName" value="CACHE_CONSUMER" />
         -->
-
-        <!--
-            Set the credentials using environment variables.
-            Variable names are 'ACTIVEMQ_BROKER_USERNAME' and 'ACTIVEMQ_BROKER_PASSWORD'.
-        -->
-        <property name="userName" value="${activemq.broker.username:#{null}}" />
-        <property name="password" value="${activemq.broker.password:#{null}}" />
     </bean>
 
 </beans>

--- a/src/main/resources/META-INF/spring/amq.xml
+++ b/src/main/resources/META-INF/spring/amq.xml
@@ -1,38 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
 
     <!-- Discovers the ActiveMQ service dynamically -->
-    <bean id="jmsConnectionFactory" class="io.fabric8.mq.core.MQConnectionFactory">
+    <bean id="jmsConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+
         <!--
-            If required, you can set the broker credentials using environment variables.
-            Variable names are 'ACTIVEMQ_BROKER_USERNAME' and 'ACTIVEMQ_BROKER_PASSWORD'.
+            The following properties can be customized in the application.properties file.
+            Values can be changed using external environment variables (see application.properties for details).
         -->
-        <property name="userName" value="${activemq.broker.username:#{null}}" />
-        <property name="password" value="${activemq.broker.password:#{null}}" />
+
+        <property name="brokerURL" value="${activemq.broker.url}"/>
+        <property name="userName" value="${activemq.broker.username:#{null}}"/>
+        <property name="password" value="${activemq.broker.password:#{null}}"/>
     </bean>
 
     <bean primary="true" id="pooledConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory" init-method="start" destroy-method="stop">
-        <property name="maxConnections" value="8"/>
+        <property name="maxConnections" value="${activemq.pool.max.connections}"/>
         <property name="connectionFactory" ref="jmsConnectionFactory"/>
     </bean>
 
     <bean id="jmsConfig" class="org.apache.activemq.camel.component.ActiveMQConfiguration">
         <property name="connectionFactory" ref="pooledConnectionFactory"/>
-        <property name="concurrentConsumers" value="10"/>
+        <property name="concurrentConsumers" value="${activemq.concurrent.consumers}"/>
     </bean>
 
     <bean id="amq" class="org.apache.activemq.camel.component.ActiveMQComponent">
         <property name="configuration" ref="jmsConfig"/>
-        <!--
-        If we are using transacted then enable CACHE_CONSUMER (if not using XA)
-        to run faster see more details at: http://camel.apache.org/jms
-
-        <property name="transacted" value="true"/>
-        <property name="cacheLevelName" value="CACHE_CONSUMER" />
-        -->
     </bean>
 
 </beans>

--- a/src/main/resources/META-INF/spring/amq.xml
+++ b/src/main/resources/META-INF/spring/amq.xml
@@ -12,7 +12,7 @@
         <property name="connectionFactory" ref="jmsConnectionFactory"/>
     </bean>
 
-    <bean id="jmsConfig" class="org.apache.camel.component.jms.JmsConfiguration">
+    <bean id="jmsConfig" class="org.apache.activemq.camel.component.ActiveMQConfiguration">
         <property name="connectionFactory" ref="pooledConnectionFactory"/>
         <property name="concurrentConsumers" value="10"/>
     </bean>
@@ -26,6 +26,13 @@
         <property name="transacted" value="true"/>
         <property name="cacheLevelName" value="CACHE_CONSUMER" />
         -->
+
+        <!--
+            Set the credentials using environment variables.
+            Variable names are 'ACTIVEMQ_BROKER_USERNAME' and 'ACTIVEMQ_BROKER_PASSWORD'.
+        -->
+        <property name="userName" value="${activemq.broker.username:#{null}}" />
+        <property name="password" value="${activemq.broker.password:#{null}}" />
     </bean>
 
 </beans>

--- a/src/main/resources/META-INF/spring/camel-context.xml
+++ b/src/main/resources/META-INF/spring/camel-context.xml
@@ -20,7 +20,7 @@
           The amq component ensures to use the broker in the kubernetes cluster.
         -->
         <route id="generate-order">
-            <from uri="timer:order?period=5000"/>
+            <from uri="timer:order?period=3000"/>
             <bean ref="orderGenerator" method="generateOrder"/>
             <setHeader headerName="Exchange.FILE_NAME">
                 <!-- defining the header containing a simulated file name -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,28 @@ camel.springboot.name=CamelActiveMQ
 
 # Keeps the application alive
 camel.springboot.main-run-controller=true
+
+# The name of the service hosting the ActiveMQ broker or message gateway
+# Can be customized using the 'ACTIVEMQ_SERVICE_NAME' variable to use a different broker.
+activemq.service.name=activemq
+
+# The following properties can be customized using the 'ACTIVEMQ_SERVICE_HOST' and 'ACTIVEMQ_SERVICE_PORT' environment variables.
+# This is indeed done automatically by Kubernetes when the application is deployed in a namespace containing an instance of ActiveMQ named 'activemq'.
+# The service defaults to localhost. You need to change these properties for development purposes only.
+activemq.service.host=127.0.0.1
+activemq.service.port=61616
+
+
+# The following property binds all previous configurations together
+activemq.broker.url=tcp://${${activemq.service.name}.service.host}:${${activemq.service.name}.service.port}
+
+# Set the number of concurrent consumers for the ActiveMQ ('ACTIVEMQ_CONCURRENT_CONSUMERS')
+activemq.concurrent.consumers=10
+
+# Set the number of connections created by the connection pool ('ACTIVEMQ_POOL_MAX_CONNECTIONS')
+activemq.pool.max.connections=8
+
+# If required, you can set the broker credentials using environment variables.
+# Variable names are 'ACTIVEMQ_BROKER_USERNAME' and 'ACTIVEMQ_BROKER_PASSWORD'.
+#activemq.broker.username=theuser
+#activemq.broker.password=thepassword


### PR DESCRIPTION
Changed the quickstart to allow an user to provide the broker username/password through internal or external configuration.

It works with unauthenticated brokers too..