### PR TITLE
Avoid warnings as no xsd is provided

### DIFF
--- a/src/main/resources/data/order1.xml
+++ b/src/main/resources/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order>
 
     <customer id="A0001">

--- a/src/main/resources/data/order2.xml
+++ b/src/main/resources/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order>
 
     <customer id="B0002">

--- a/src/main/resources/data/order3.xml
+++ b/src/main/resources/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order>
 
     <customer id="C0003">

--- a/src/main/resources/data/order4.xml
+++ b/src/main/resources/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order>
 
     <customer id="D0004">

--- a/src/main/resources/data/order5.xml
+++ b/src/main/resources/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order>
 
     <customer id="E0004">


### PR DESCRIPTION
decalre doctype to XML to avoid warnings as there is no xsd provided