### PR TITLE
Add arquillian cube version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <!-- dependency versions -->
     <fabric8.version>2.3.7</fabric8.version>
     <spring-boot.version>1.5.4.RELEASE</spring-boot.version>
+    <arquillian-cube.version>1.9.0</arquillian-cube.version>
 
     <!-- maven plugin versions -->
     <fabric8.maven.plugin.version>3.5.31</fabric8.maven.plugin.version>
@@ -84,6 +85,7 @@
     <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-openshift</artifactId>
+      <version>${arquillian-cube.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fuse 7 pipeline build is failing due to lack of arquillian-cube-openshift version.