### PR TITLE
[ENTESB-10710] Fabric8 quickstart spring-boot-camel-amq does not work correctly (probably missing configuration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,52 @@
 
 This quickstart demonstrates how to connect a Spring-Boot application to EnMasse (MaaS) and use JMS messaging between two Camel routes using Kubernetes or OpenShift.
 
-This quickstart requires EnMasse to have been deployed and running first. Follow the directions at
-
-http://enmasse.io/documentation
-
-to install EnMasse into OpenShift or Kubernetes. There is a `deploy.sh` script that will help you install EnMasse. Once EnMasse is installed, please create an incomingOrders queue using the EnMasse console.
+This quickstart requires EnMasse to have been deployed and running first. To install EnMasse into OpenShift or Kubernetes follow [documentation](https://enmasse.io/documentation/master/openshift/#installing-messaging).
 
 ### Configuration
 
 The quickstart must run on a Kubernetes/OpenShift project different from the one where EnMasse is deployed.
 
-Before running the quickstart, you need to configure the `src/main/fabric8/deployment.yml` file in order to 
-use the correct remote instance of AMQ EnMasse.
-The `AMQP_SERVICE_NAME` environment variable must point to the hostname of the external "messaging" route exposed by EnMasse.
+Log in as a user with cluster-admin privileges:
+
+ ```
+ oc login -u system:admin
+ ```
+
+Before running the quickstart, you need to configure EnMasse (create user and queue). Run the following commands to create new project and apply configuration files:
+
+ ```
+ oc new-project MY_PROJECT_NAME
+ oc apply -f src/main/resources/k8s
+ ```
 
 ### Building
 
 The example can be built with
 
-    mvn clean install
-
+ ```
+ mvn clean install
+ ```
 
 ### Running the example locally
 
-The example can be run locally using the following Maven goal:
+Before running the quickstart, you need to configure the `src/main/fabric8/deployment.yml` file in order to
+use the correct remote instance of AMQ EnMasse.
 
-    mvn spring-boot:run
 
+Get remote url of EnMasse instance by running following command:
+
+ ```
+ oc get addressspace spring-boot-camel-amq -o jsonpath={.status.endpointStatuses[?(@.name==\'messaging\')].externalHost}
+ ```
+
+Fill this value into `src/main/resources/application.properties` instead of `FILL_ME`.
+
+The example can be then run locally using the following Maven goal:
+
+ ```
+ mvn spring-boot:run
+ ```
 
 ### Running the example in Kubernetes/OpenShift
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <!-- dependency versions -->
     <fabric8.version>3.0.11.fuse-730061</fabric8.version>
+    <io.netty.version>4.1.28.Final</io.netty.version>
 
     <!-- maven plugin versions -->
     <fabric8.maven.plugin.version>3.5.34</fabric8.maven.plugin.version>
@@ -80,6 +81,18 @@
       <groupId>org.messaginghub</groupId>
       <artifactId>pooled-jms</artifactId>
       <version>${pooled-jms.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${io.netty.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <version>${io.netty.version}</version>
+      <artifactId>netty-handler</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/fabric8/deployment.yml
+++ b/src/main/fabric8/deployment.yml
@@ -12,11 +12,17 @@ spec:
               cpu: "1.0"
               memory: 256Mi
           env:
+          - name: AMQP_PROTOCOL
+            value: amqp
           - name: AMQP_SERVICE_NAME
-            value: messaging-enmasse.192.168.64.1.nip.io
-          - name: AMQP_USERNAME
-            value: admin
-          - name: AMQP_PASSWORD
-            value: admin
+            valueFrom:
+              configMapKeyRef:
+                name: spring-boot-camel-amq-config
+                key: service.host
+          - name: AMQP_SERVICE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: spring-boot-camel-amq-config
+                key: service.port.amqp
           - name: AMQP_PARAMETERS
             value: transport.trustAll=true&transport.verifyHost=false&amqp.idleTimeout=120000

--- a/src/main/java/io/fabric8/quickstarts/camel/amq/AMQPConfiguration.java
+++ b/src/main/java/io/fabric8/quickstarts/camel/amq/AMQPConfiguration.java
@@ -11,6 +11,11 @@ import org.springframework.context.annotation.Configuration;
 public class AMQPConfiguration {
 
     /**
+     * AMQ protocol
+     */
+    private String protocol;
+
+    /**
      * AMQ service name
      */
     private String serviceName;
@@ -24,6 +29,11 @@ public class AMQPConfiguration {
      * AMQ username
      */
     private String username;
+
+    /**
+     * AMQ service port
+     */
+    private String servicePort;
 
     /**
      * AMQ password
@@ -57,6 +67,14 @@ public class AMQPConfiguration {
         this.username = username;
     }
 
+    public String getServicePort() {
+        return servicePort;
+    }
+
+    public void setServicePort(String servicePort) {
+        this.servicePort = servicePort;
+    }
+
     public String getPassword() {
         return password;
     }
@@ -65,4 +83,11 @@ public class AMQPConfiguration {
         this.password = password;
     }
 
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
 }

--- a/src/main/java/io/fabric8/quickstarts/camel/amq/Application.java
+++ b/src/main/java/io/fabric8/quickstarts/camel/amq/Application.java
@@ -36,8 +36,9 @@ public class Application {
     }
 
     @Bean(name = "amqp-component")
-    AMQPComponent amqpComponent(AMQPConfiguration config) {
-        String remoteURI = String.format("amqps://%s:443?%s", config.getServiceName(), config.getParameters());
+    AMQPComponent amqpComponent(AMQPConfiguration config) throws Exception {
+        String remoteURI = String.format("%s://%s:%s?%s", config.getProtocol(), config.getServiceName(), config.getServicePort(), config.getParameters());
+
         JmsConnectionFactory qpid = new JmsConnectionFactory(config.getUsername(), config.getPassword(), remoteURI);
 
         JmsPoolConnectionFactory factory = new JmsPoolConnectionFactory();
@@ -45,5 +46,4 @@ public class Application {
 
         return new AMQPComponent(factory);
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,8 +14,10 @@ camel.springboot.name=CamelAMQ
 camel.springboot.main-run-controller=true
 
 # Amqp connection configuration (is overridden in Kubernetes/OpenShift using src/main/fabric8/deployment.yml)
-amqp.service.name=messaging-enmasse.192.168.64.1.nip.io
+amqp.protocol=amqps
+amqp.serviceName=FILL_ME
+amqp.servicePort=443
 amqp.parameters=transport.trustAll=true&transport.verifyHost=false&amqp.idleTimeout=120000
 amqp.username=admin
-amqp.password=admin
+amqp.password=test
 

--- a/src/main/resources/k8s/address_space.yaml
+++ b/src/main/resources/k8s/address_space.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: enmasse.io/v1beta1
+kind: AddressSpace
+metadata:
+  name: spring-boot-camel-amq
+spec:
+  type: brokered
+  plan: brokered-single-broker
+  endpoints:
+  - name: messaging
+    service: messaging
+    expose:
+      type: route
+      routeServicePort: amqps
+      routeTlsTermination: passthrough
+    exports:
+    - kind: ConfigMap
+      name: spring-boot-camel-amq-config
+    cert:
+      provider: openshift

--- a/src/main/resources/k8s/queue.yaml
+++ b/src/main/resources/k8s/queue.yaml
@@ -1,0 +1,8 @@
+apiVersion: enmasse.io/v1beta1
+kind: Address
+metadata:
+  name: spring-boot-camel-amq.orders
+spec:
+  address: incomingOrders
+  type: queue
+  plan: brokered-queue

--- a/src/main/resources/k8s/rbac-binding.yaml
+++ b/src/main/resources/k8s/rbac-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbac-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbac
+subjects:
+- kind: ServiceAccount
+  name: address-space-controller
+  namespace: enmasse-infra

--- a/src/main/resources/k8s/rbac.yaml
+++ b/src/main/resources/k8s/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbac
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "create" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    resourceNames: [ "spring-boot-camel-amq-config" ]
+    verbs: [ "get", "update", "patch" ]

--- a/src/main/resources/k8s/user.yaml
+++ b/src/main/resources/k8s/user.yaml
@@ -1,0 +1,12 @@
+apiVersion: user.enmasse.io/v1beta1
+kind: MessagingUser
+metadata:
+  name: spring-boot-camel-amq.client
+spec:
+  username: admin
+  authentication:
+    type: password
+    password: dGVzdA==
+  authorization:
+    - operations: ["send", "recv"]
+      addresses: ["incomingOrders"]


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-10710

Quickstart wa fixed, it can be executed on minishift and/or run lically.
Configuration of EnMasse was added into project. README was updated. Some small changes in  code and pom were necessary too. Overall it is much easier to run this quickstart.