### PR TITLE
ENTESB-12238: Quickstarts arquillian test fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- configure the Fuse version you want to use here -->
-        <fuse.bom.version>7.6.0.fuse-sb2-760027-redhat-00001</fuse.bom.version>
+        <fuse.bom.version>7.8.0.fuse-sb2-780010</fuse.bom.version>
 
         <!-- maven plugin versions -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -116,16 +116,16 @@
             </exclusions>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-assertions</artifactId>
+            <artifactId>kubernetes-model</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>2.4.1</version>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Removed kubernetes-assertion dependency in favor of kubernetes-client