### PR TITLE
[ENTESB-15989] Wrong version of docker image in quickstarts pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
         <!-- configure the Fuse version you want to use here -->
         <fuse.bom.version>7.8.0.fuse-sb2-780033</fuse.bom.version>
-        <docker.image.version>1.7</docker.image.version>
+        <docker.image.version>1.9</docker.image.version>
 
         <!-- maven plugin versions -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15989